### PR TITLE
Do not check if instances of the same job are queued

### DIFF
--- a/job.go
+++ b/job.go
@@ -420,15 +420,6 @@ func (j *Job) HasQueuedBuild() {
 }
 
 func (j *Job) InvokeSimple(ctx context.Context, params map[string]string) (int64, error) {
-	isQueued, err := j.IsQueued(ctx)
-	if err != nil {
-		return 0, err
-	}
-	if isQueued {
-		Logger.Error("%s is already running", j.GetName())
-		return 0, nil
-	}
-
 	endpoint := "/build"
 	parameters, err := j.GetParameters(ctx)
 	if err != nil {
@@ -469,14 +460,6 @@ func (j *Job) InvokeSimple(ctx context.Context, params map[string]string) (int64
 }
 
 func (j *Job) Invoke(ctx context.Context, files []string, skipIfRunning bool, params map[string]string, cause string, securityToken string) (bool, error) {
-	isQueued, err := j.IsQueued(ctx)
-	if err != nil {
-		return false, err
-	}
-	if isQueued {
-		Logger.Error("%s is already running", j.GetName())
-		return false, nil
-	}
 	isRunning, err := j.IsRunning(ctx)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Do not check for other instances of same job to be in the queue since multiple builds can be executed.